### PR TITLE
Fixed error using method URL.createObjectURL on Chrome

### DIFF
--- a/Samples/Client/WebClient/app.js
+++ b/Samples/Client/WebClient/app.js
@@ -138,12 +138,18 @@ $(function(){
   }
 
   function onRemoteStreamAdded(event) {
-    console.log('Remote stream added:', URL.createObjectURL(event.stream));
     document.getElementById('renderers').style.display = 'none';
-    remoteVideoElement = document.getElementById('remote-video');
-    remoteVideoElement.src = URL.createObjectURL(event.stream);
-    remoteVideoElement.play();
-  }
+    remoteVideoElement = document.getElementById('remote-video');    
+    try{
+      remoteVideoElement.src = URL.createObjectURL(event.stream);
+    } 
+    catch (error) {
+      remoteVideoElement.srcObject = event.stream;
+    }
+    finally{
+      remoteVideoElement.play();
+    }
+   }
 
   function joinPeer() {
     try {


### PR DESCRIPTION
Fixed error using method URL.createObjectURL on Chrome, more info here https://www.chromestatus.com/features/5618491470118912

## Description
This change fixes an unhandled exception using the now deprecated function URL.createObjectURL on Chrome. More info on the deprecated function can be found here https://www.chromestatus.com/features/5618491470118912

Related to issue [#310](https://github.com/3DStreamingToolkit/3DStreamingToolkit/issues/310) 
